### PR TITLE
Add a set of different SVG sizes

### DIFF
--- a/content/docs/guides/wiki-contribution-guide.md
+++ b/content/docs/guides/wiki-contribution-guide.md
@@ -85,6 +85,13 @@ Do this:
 {{<svg "my-wiki/my-fig-2">}}
 ```
 
+SVG sizing is a surprisingly tricky deal.
+Currently we have four different sizes:
+- svg : 100%
+- svg-smaller : 75%
+- svg-small : 50%
+- svg-tiny : 25%
+
 ## Documentation versioning 
 
 To archive the current version of the docs you need to do the following:

--- a/layouts/shortcodes/svg-small.html
+++ b/layouts/shortcodes/svg-small.html
@@ -1,0 +1,12 @@
+{{ $svgName := index .Params 0 }}
+{{ $pageDir := .Page.File.Dir }}
+
+{{ $lightSvgPath := printf "%ssvgs/%s/light.svg" $pageDir $svgName }}
+{{ $darkSvgPath := printf "%ssvgs/%s/dark.svg" $pageDir $svgName }}
+
+<figure class="svg-lightmode constrain-image" style="width: 50%;">
+    {{ readFile $lightSvgPath | safeHTML }}
+</figure>
+<figure class="svg-darkmode constrain-image" style="width: 50%;">
+    {{ readFile $darkSvgPath | safeHTML }}
+</figure>

--- a/layouts/shortcodes/svg-smaller.html
+++ b/layouts/shortcodes/svg-smaller.html
@@ -1,0 +1,12 @@
+{{ $svgName := index .Params 0 }}
+{{ $pageDir := .Page.File.Dir }}
+
+{{ $lightSvgPath := printf "%ssvgs/%s/light.svg" $pageDir $svgName }}
+{{ $darkSvgPath := printf "%ssvgs/%s/dark.svg" $pageDir $svgName }}
+
+<figure class="svg-lightmode constrain-image" style="width: 75%;">
+    {{ readFile $lightSvgPath | safeHTML }}
+</figure>
+<figure class="svg-darkmode constrain-image" style="width: 75%;">
+    {{ readFile $darkSvgPath | safeHTML }}
+</figure>

--- a/layouts/shortcodes/svg-tiny.html
+++ b/layouts/shortcodes/svg-tiny.html
@@ -1,0 +1,12 @@
+{{ $svgName := index .Params 0 }}
+{{ $pageDir := .Page.File.Dir }}
+
+{{ $lightSvgPath := printf "%ssvgs/%s/light.svg" $pageDir $svgName }}
+{{ $darkSvgPath := printf "%ssvgs/%s/dark.svg" $pageDir $svgName }}
+
+<figure class="svg-lightmode constrain-image" style="width: 25%;">
+    {{ readFile $lightSvgPath | safeHTML }}
+</figure>
+<figure class="svg-darkmode constrain-image" style="width: 25%;">
+    {{ readFile $darkSvgPath | safeHTML }}
+</figure>


### PR DESCRIPTION
SVG sizing is a surprisingly tricky deal.
Currently we have four different sizes:
- svg : 100%
- svg-smaller : 75%
- svg-small : 50%
- svg-tiny : 25%

![image](https://github.com/user-attachments/assets/30045702-6a91-46ce-9e76-2310be83bcc9)

This is by far not the best or optimal solution - but after several hours of trying to conjure up (S)CSS arcana nothing turned out to work but this.