### PR TITLE
Enhance custom SVG usage

### DIFF
--- a/assets/scss/common/_custom.scss
+++ b/assets/scss/common/_custom.scss
@@ -748,3 +748,19 @@ table.alt tfoot {
   text-align: center;
   color: #6d7993;
 }
+
+.container {
+  display: grid;
+  width: 100%;
+  height: auto;
+  justify-items: center;
+}
+
+.constrain-image {
+  max-width: 100% !important;
+  height: auto !important;
+}
+.constrain-image svg {
+  width: 100% !important;
+  height: auto !important;
+}

--- a/content/docs/guides/wiki-contribution-guide.md
+++ b/content/docs/guides/wiki-contribution-guide.md
@@ -92,6 +92,20 @@ Currently we have four different sizes:
 - svg-small : 50%
 - svg-tiny : 25%
 
+You can also have an svg and a block of text next to each other.
+For this use the custom `svg-paragraph` shortcode.
+
+```bash
+{{<svg-paragraph svg="my-svg-name" alignment="right">}}
+    My cool paragraph.
+    Any text should be fine.
+    Even like this: <i> hi </i> bye.
+{{< /svg-paragraph >}}
+```
+
+Supported aligmnets: "right", "left"
+
+
 ## Documentation versioning 
 
 To archive the current version of the docs you need to do the following:

--- a/layouts/shortcodes/svg-paragraph.html
+++ b/layouts/shortcodes/svg-paragraph.html
@@ -1,0 +1,53 @@
+{{ $svgName := .Get "svg" }}
+{{ $alignment := default "right" (.Get "alignment") }}
+{{ $pageDir := .Page.File.Dir }}
+
+{{ $lightSvgPath := printf "%ssvgs/%s/light.svg" $pageDir $svgName }}
+{{ $darkSvgPath := printf "%ssvgs/%s/dark.svg" $pageDir $svgName }}
+
+<style>
+    .grid {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+    }
+
+    .col-30 {
+        width: 30%;
+    }
+
+    .col-70 {
+        width: 70%;
+    }
+
+    .content {
+        padding: 10px;
+    }
+</style>
+
+<div class="grid">
+    {{ if eq $alignment "right"}}
+        <div class="col-70">
+            <div class="content">
+            {{ .Inner | safeHTML }}
+            </div>
+        </div>
+    {{ end }}
+    <div class="col-30">
+        <div class="content">
+            <figure class="svg-lightmode constrain-image center">
+                {{ readFile $lightSvgPath | safeHTML }}
+            </figure>
+            <figure class="svg-darkmode constrain-image center">
+                {{ readFile $darkSvgPath | safeHTML }}
+            </figure>
+        </div>
+    </div>
+    {{ if eq $alignment "left"}}
+        <div class="col-70">
+            <div class="content">
+            {{ .Inner | safeHTML }}
+            </div>
+        </div>
+    {{ end }}
+</div>

--- a/layouts/shortcodes/svg-small.html
+++ b/layouts/shortcodes/svg-small.html
@@ -4,9 +4,13 @@
 {{ $lightSvgPath := printf "%ssvgs/%s/light.svg" $pageDir $svgName }}
 {{ $darkSvgPath := printf "%ssvgs/%s/dark.svg" $pageDir $svgName }}
 
-<figure class="svg-lightmode constrain-image" style="width: 50%;">
-    {{ readFile $lightSvgPath | safeHTML }}
-</figure>
-<figure class="svg-darkmode constrain-image" style="width: 50%;">
-    {{ readFile $darkSvgPath | safeHTML }}
-</figure>
+<div class="container">
+    <div class="box" style="width: 50%">
+        <figure class="svg-lightmode constrain-image">
+            {{ readFile $lightSvgPath | safeHTML }}
+        </figure>
+        <figure class="svg-darkmode constrain-image">
+            {{ readFile $darkSvgPath | safeHTML }}
+        </figure>
+    </div>
+</div>

--- a/layouts/shortcodes/svg-smaller.html
+++ b/layouts/shortcodes/svg-smaller.html
@@ -4,9 +4,13 @@
 {{ $lightSvgPath := printf "%ssvgs/%s/light.svg" $pageDir $svgName }}
 {{ $darkSvgPath := printf "%ssvgs/%s/dark.svg" $pageDir $svgName }}
 
-<figure class="svg-lightmode constrain-image" style="width: 75%;">
-    {{ readFile $lightSvgPath | safeHTML }}
-</figure>
-<figure class="svg-darkmode constrain-image" style="width: 75%;">
-    {{ readFile $darkSvgPath | safeHTML }}
-</figure>
+<div class="container">
+    <div class="box" style="width: 75%">
+        <figure class="svg-lightmode constrain-image">
+            {{ readFile $lightSvgPath | safeHTML }}
+        </figure>
+        <figure class="svg-darkmode constrain-image">
+            {{ readFile $darkSvgPath | safeHTML }}
+        </figure>
+    </div>
+</div>

--- a/layouts/shortcodes/svg-tiny.html
+++ b/layouts/shortcodes/svg-tiny.html
@@ -4,9 +4,13 @@
 {{ $lightSvgPath := printf "%ssvgs/%s/light.svg" $pageDir $svgName }}
 {{ $darkSvgPath := printf "%ssvgs/%s/dark.svg" $pageDir $svgName }}
 
-<figure class="svg-lightmode constrain-image" style="width: 25%;">
-    {{ readFile $lightSvgPath | safeHTML }}
-</figure>
-<figure class="svg-darkmode constrain-image" style="width: 25%;">
-    {{ readFile $darkSvgPath | safeHTML }}
-</figure>
+<div class="container">
+    <div class="box" style="width: 25%">
+        <figure class="svg-lightmode constrain-image">
+            {{ readFile $lightSvgPath | safeHTML }}
+        </figure>
+        <figure class="svg-darkmode constrain-image">
+            {{ readFile $darkSvgPath | safeHTML }}
+        </figure>
+    </div>
+</div>

--- a/layouts/shortcodes/svg.html
+++ b/layouts/shortcodes/svg.html
@@ -4,21 +4,13 @@
 {{ $lightSvgPath := printf "%ssvgs/%s/light.svg" $pageDir $svgName }}
 {{ $darkSvgPath := printf "%ssvgs/%s/dark.svg" $pageDir $svgName }}
 
-<style>
-    .constrain-image {
-        max-width: 100% !important;
-        height: auto !important;
-    }
-
-    .constrain-image svg {
-        width: 100% !important;
-        height: auto !important;
-    }
-</style>
-
-<figure class="svg-lightmode constrain-image">
-    {{ readFile $lightSvgPath | safeHTML }}
-</figure>
-<figure class="svg-darkmode constrain-image">
-    {{ readFile $darkSvgPath | safeHTML }}
-</figure>
+<div class="container">
+    <div class="box" style="width: 100%">
+        <figure class="svg-lightmode constrain-image">
+            {{ readFile $lightSvgPath | safeHTML }}
+        </figure>
+        <figure class="svg-darkmode constrain-image">
+            {{ readFile $darkSvgPath | safeHTML }}
+        </figure>
+    </div>
+</div>


### PR DESCRIPTION
Even more enhancements

Now the svgs are horizontally centered
and we have a new custom shortcode svg-paragraph to display svgs with text inline

![image](https://github.com/user-attachments/assets/defba6ee-5946-4585-8d2a-97e5a0fb62b8)
![image](https://github.com/user-attachments/assets/c17baf0f-4852-4117-b978-2d01b7499c3c)
